### PR TITLE
Pillow upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
   - pip install -U pip
 
 install:
-  - pip install -r requirements.txt
+  - timeout 120 pip install -r requirements.txt
 
 script:
   - sh unittest.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,13 @@ python:
   - 3.7
   - 3.8
   - 3.9
-  - 3.9-dev
-  - 3.10-dev
+  - 3.10
+  - nightly
 
 jobs:
   allow_failures:
-    - python: 3.9-dev
-    - python: 3.10-dev
+    - python: 3.10
+    - python: nightly
 
 before_install:
   - python --version

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Version 1.9.1, 2021-09-08
+--------------------------
+- add pip install timeout to prevent Travis CI jobs from hanging
+- bump pillow from 8.2.0 to 8.3.2 (dependabot security vulnerability)
+
+
 1.9.0 (2021-06-16)
 ------------------
 - upgrade Py dependency

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ packbits==0.6
 parso==0.8.2
 pexpect==4.8.0
 pickleshare==0.7.5
-Pillow==8.2.0
+Pillow==8.3.2
 pluggy==0.13.1
 prompt-toolkit==3.0.18
 ptyprocess==0.7.0


### PR DESCRIPTION
- add pip install timeout to prevent Travis CI jobs from hanging
- bump pillow from 8.2.0 to 8.3.2 (dependabot security vulnerability)