### PR TITLE
Remove Python 3.7 support

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9"]
 
     name: Python ${{ matrix.python-version }} (${{ matrix.os }})
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,20 @@
 appnope==0.1.2
+asttokens==2.4.1
 atomicwrites==1.4.0
 attrs==21.2.0
 backcall==0.2.0
 decorator==5.0.9
 docopt==0.6.2
+executing==2.0.1
 ExifRead==2.3.2
 ImageHash==4.2.0
 iniconfig==1.1.1
-ipython>=7.31.1
+ipython==8.8.0
 ipython-genutils==0.2.0
 jedi==0.18.0
 matplotlib-inline==0.1.2
 more-itertools==8.8.0
-numpy>=1.19.0,<=1.20.3
+numpy==1.20.3
 packaging==20.9
 packbits==0.6
 parso==0.8.2
@@ -22,15 +24,17 @@ Pillow==9.3.0
 pluggy==0.13.1
 prompt-toolkit==3.0.18
 ptyprocess==0.7.0
+pure-eval==0.2.2
 py==1.10.0
 PyBundle==1.0.6
 Pygments==2.15.0
--e git+https://github.com/ojii/pymaging.git#egg=pymaging
+-e git+https://github.com/ojii/pymaging.git@596a08fce5664e58d6e8c96847393fbe987783f2#egg=pymaging
 pyparsing==2.4.7
 pytest==6.2.4
 PyWavelets==1.1.1
-scipy>=1.5.0,<=1.6.3
+scipy==1.6.3
 six==1.16.0
+stack-data==0.6.3
 toml==0.10.2
-traitlets>=4.0.0,<=5.0.5
+traitlets==5.0.5
 wcwidth==0.2.5

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def get_version():
 setup(
     name='psd-tools3',
     version=get_version(),
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     author='Stephen Neal',
     author_email='stephen@stephenneal.net',
     url='https://github.com/sfneal/psd-tools3',
@@ -39,7 +39,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
- remove support for Python 3.7 to make transition to latest Python versions easier
- add full version locks in requirements.txt dependencies