### PR TITLE
Remove support for Python 3.8

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.9"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.9"]
 
     name: Python ${{ matrix.python-version }} (${{ matrix.os }})
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def get_version():
 setup(
     name='psd-tools3',
     version=get_version(),
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     author='Stephen Neal',
     author_email='stephen@stephenneal.net',
     url='https://github.com/sfneal/psd-tools3',
@@ -39,7 +39,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
- remove support for Python 3.8
- needed to cut support to ease transition to latest Python versions